### PR TITLE
Made Re::asArray recurse into arrays of arrays

### DIFF
--- a/Lib/Re.php
+++ b/Lib/Re.php
@@ -33,7 +33,9 @@ class Re {
 		}
 		// get all first level nested objects (if any)
 		foreach ( $input as $key => $val ) {
-			if (is_object($val)) {
+			if (is_object($val)) { // Recurse into objects
+				$input[$key] = Re::asArray($val);
+			} elseif (is_array($val)) { // Recurse into arrays of arrays
 				$input[$key] = Re::asArray($val);
 			}
 		}


### PR DESCRIPTION
Currently this fails to recurse down deep enough to the objects

array('interests' => array( new stdClass(), new stdClass() ) )

This is used in a lot of places though and I don't know if this will blow things up. Can you check it out? If it's no good I'll add it as a function argument
