### PR TITLE
MysqlExtended now wraps execute() DEADLOCKS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
 

--- a/Model/Datasource/Database/MysqlExtended.php
+++ b/Model/Datasource/Database/MysqlExtended.php
@@ -35,7 +35,24 @@ class MysqlExtended extends Mysql {
 		'mediumint' => array('name' => 'mediumint', 'limit' => '8', 'formatter' => 'intval'),
 	);
 
+	/**
+	 * Config for tryExecuteAgain()
+	 *
+	 * @var array
+	 */
+	public $_tryExecuteAgainConfig = [
+		'limit' => 3,     // retry 3 times (change to 0 to disable retrys)
+		'usleep' => 1000, // 1 ms
+	];
 
+	/**
+	 * Customized: more options/types
+	 *
+	 * Converts database-layer column types to basic types
+	 *
+	 * @param string $real Real database-layer column type (i.e. "varchar(255)")
+	 * @return string Abstract column type (i.e. "string")
+	 */
 	public function column($real) {
 		if (is_array($real)) {
 			$col = $real['name'];
@@ -97,6 +114,171 @@ class MysqlExtended extends Mysql {
 			return "enum($vals)";
 		}
 		return 'text';
+	}
+
+/**
+ * Customized: we try/catch trapping the PDOException
+ *
+ * Given a PDOException
+ * When the exception message contains "try restarting transaction"
+ * And when we have not restarted 3 times already
+ * Then restart the execute on the exact same query again
+ *
+ * This is a method to help mitigate MySQL / Percona DEADLOCK errors in InnoDB tables
+ *
+ * The deadlocks are actually things working right... MySQL recomments restarting...
+ *
+ * So the application code should be capable of simple restarting... i
+ * thus this extension.
+ *
+ *
+ * Queries the database with given SQL statement, and obtains some metadata about the result
+ * (rows affected, timing, any errors, number of rows in resultset). The query is also logged.
+ * If Configure::read('debug') is set, the log is shown all the time, else it is only shown on errors.
+ *
+ * ### Options
+ *
+ * - log - Whether or not the query should be logged to the memory log.
+ *
+ * @param string $sql SQL statement
+ * @param array $options The options for executing the query.
+ * @param array $params values to be bound to the query.
+ * @return mixed Resource or object representing the result set, or false on failure
+ */
+	public function execute($sql, $options = array(), $params = array()) {
+		try {
+			return $this->executeOnParent($sql, $options, $params);
+		} catch (PDOException $e) {
+			$return = $this->tryExecuteAgain($e, $sql, $options, $params);
+			$this->tryExecuteAgainUnsetRepeat();
+			return $return;
+		}
+	}
+
+	/**
+	 * Split out to parent caller function - for easier testing/mocking
+	 *
+	 * @param string $sql SQL statement
+	 * @param array $options The options for executing the query.
+	 * @param array $params values to be bound to the query.
+	 * @return mixed Resource or object representing the result set, or false on failure
+	 */
+	public function executeOnParent($sql, $options = array(), $params = array()) {
+		return parent::execute($sql, $options, $params);
+	}
+
+	/**
+	 * try to re-execute again, maybe
+	 * based on the query, exception, etc
+	 *
+	 * @param PDOException $e
+	 * @param string $sql SQL statement
+	 * @param array $options The options for executing the query.
+	 * @param array $params values to be bound to the query.
+	 * @return mixed Resource or object representing the result set, or false on failure
+	 */
+	public function tryExecuteAgain($e, $sql, $options, $params) {
+		if (!$this->shouldWeExecuteAgain($e)) {
+			$this->log('MysqlExtended: Did not retry query THROWING: ' . $sql);
+			throw $e;
+		}
+		$this->tryExecuteAgainSleep($e);
+		$this->tryExecuteAgainAddRepeat($e);
+
+		$this->log('MysqlExtended: Attempting to retry query: ' . $sql);
+		$return = $this->execute($sql, $options, $params);
+		$this->log('MysqlExtended: Successful retry of query: ' . $sql);
+
+		return $return;
+	}
+
+	/**
+	 * should we try to re-execute again?
+	 * based on the query, exception, etc
+	 *
+	 * @param PDOException $e
+	 * @return boolean
+	 */
+	public function shouldWeExecuteAgain($e) {
+		if (!($e instanceof PDOException)) {
+			return false;
+		}
+		if (!isset($e->queryString)) {
+			return false;
+		}
+		if (!$this->shouldWeExecuteAgainAllowedMessage($e)) {
+			return false;
+		}
+		if (!$this->shouldWeExecuteAgainAllowedRepeat($e)) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * should we try to re-execute again?
+	 * based on the query message
+	 *
+	 * @param PDOException $e
+	 * @return boolean
+	 */
+	public function shouldWeExecuteAgainAllowedMessage($e) {
+		// TODO consider limiting to specific error codes: 1213, 1205
+		return (strpos($e->getMessage(), 'try restarting transaction') !== false);
+	}
+
+	/**
+	 * should we try to re-execute again?
+	 * based on the already repeated X times
+	 *
+	 * @param PDOException $e
+	 * @return boolean
+	 */
+	public function shouldWeExecuteAgainAllowedRepeat($e) {
+		if (!isset($this->_tryExecuteAgain[$e->queryString])) {
+			$this->_tryExecuteAgain[$e->queryString] = 0;
+		}
+		return ($this->_tryExecuteAgain[$e->queryString] < $this->_tryExecuteAgainConfig['limit']);
+	}
+
+	/**
+	 * add 1 to the count of retries for this query
+	 *
+	 * @param PDOException $e
+	 * @return boolean
+	 */
+	public function tryExecuteAgainAddRepeat($e) {
+		if (!isset($this->_tryExecuteAgain[$e->queryString])) {
+			$this->_tryExecuteAgain[$e->queryString] = 1;
+			return;
+		}
+		$this->_tryExecuteAgain[$e->queryString]++;
+	}
+
+	/**
+	 * add 1 to the count of retries for this query
+	 *
+	 * @return boolean
+	 */
+	public function tryExecuteAgainUnsetRepeat() {
+		unset($this->_tryExecuteAgain);
+	}
+
+	/**
+	 * add 1 to the count of retries for this query
+	 *
+	 * @param PDOException $e
+	 * @return boolean
+	 */
+	public function tryExecuteAgainSleep($e) {
+		if (strpos($e->getMessage(), '1205') !== false) {
+			// error 1205 is a long timeout, so we sleep longer: 100 ms
+			usleep(10000);
+			return true;
+		}
+		// default: sleep 1 ms
+		usleep($this->_tryExecuteAgainConfig['usleep']);
+		return true;
 	}
 
 }

--- a/Model/Datasource/Database/MysqlExtended.php
+++ b/Model/Datasource/Database/MysqlExtended.php
@@ -179,6 +179,7 @@ class MysqlExtended extends Mysql {
 	 */
 	public function tryExecuteAgain($e, $sql, $options, $params) {
 		if (!$this->shouldWeExecuteAgain($e)) {
+			$this->tryExecuteAgainUnsetRepeat();
 			$this->log('MysqlExtended: Did not retry query THROWING: ' . $sql);
 			throw $e;
 		}

--- a/Model/IcingVersion.php
+++ b/Model/IcingVersion.php
@@ -200,12 +200,13 @@ class IcingVersion extends IcingAppModel {
 		if (empty($data['is_minor_version']) && !empty($settings['minor_timeframe'])) {
 			// find all the records which "should be minor"
 			$versions_within_timeframe = $this->find('list', array(
+				'fields' => array('id'),
 				'conditions' => array_merge($conditions, array(
 					'IcingVersion.created >=' => date("Y-m-d H:i:s", strtotime("-{$settings['minor_timeframe']} seconds", time())),
 					'IcingVersion.is_minor_version' => false,
 				)),
 			));
-			foreach ($versions_within_timeframe as $version_id => $model) {
+			foreach ($versions_within_timeframe as $version_id) {
 				$this->id = $version_id;
 				$this->saveField('is_minor_version', true);
 			}

--- a/Test/Case/Model/Datasource/Database/MysqlExtendedTest.php
+++ b/Test/Case/Model/Datasource/Database/MysqlExtendedTest.php
@@ -1,0 +1,373 @@
+<?php
+
+App::uses('Model', 'Model');
+App::uses('AppModel', 'Model');
+App::uses('Mysql', 'Model/Datasource/Database');
+App::uses('MysqlExtended', 'Icing.Model/Datasource/Database');
+App::uses('CakeSchema', 'Model');
+
+
+class Article extends AppModel {
+	public $useTable = 'articles';
+}
+
+
+class MysqlExtendedTest extends CakeTestCase {
+
+	public $autoFixtures = true;
+	public $fixtures = array(
+		'core.article',
+	);
+	public $Dbo = null;
+	public $Article = null;
+
+	/**
+	 * Sets up a Dbo class instance for testing
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->Dbo = ConnectionManager::getDataSource('test');
+		if (!($this->Dbo instanceof MysqlExtended)) {
+			$this->markTestSkipped('The MySQL Datasource MysqlExtended extension is not available.');
+		}
+		$this->_debug = Configure::read('debug');
+		Configure::write('debug', 1);
+		$this->Article = ClassRegistry::init('Article');
+
+		// Mock it all up
+		$this->DboMock = $this->getMock('MysqlExtended', [
+			'connect',
+			'describe',
+			'executeOnParent',
+		]);
+
+		// mock the connection, so it hits the real DB
+		$this->DboMock
+			->expects($this->any())
+			->method('connect')
+			->will($this->returnValue($this->Dbo->connect()));
+
+		$this->DboMock
+			->expects($this->any())
+			->method('describe')
+			->will($this->returnValue($this->Dbo->describe($this->Article)));
+
+		// mock the exception
+		$this->e = new PDOException('SQLSTATE[HY000]: General error: 1205 Lock wait timeout exceeded; try restarting transaction');
+		$this->e->queryString = 'DELETE `IcingVersion` WHERE `id` = 1';
+
+		$this->DboMock
+			->expects($this->any())
+			->method('executeOnParent')
+			->will($this->throwException($this->e));
+
+		$this->ArticleMock = $this->getMockForModel('Article', array('getDataSource'));
+		$this->ArticleMock
+			->expects($this->any())
+			->method('getDataSource')
+			->will($this->returnValue($this->DboMock));
+	}
+
+	/**
+	 * Sets up a Dbo class instance for testing
+	 *
+	 * @return void
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		unset($this->Article);
+		unset($this->Dbo);
+		unset($this->e);
+		unset($this->DboMock);
+		unset($this->ArticleMock);
+		ClassRegistry::flush();
+		Configure::write('debug', $this->_debug);
+	}
+
+	public function testSetup() {
+
+		// unmocked, working...
+		$article = $this->Article->find('first');
+		$this->assertEqual(
+			$article['Article']['id'],
+			1
+		);
+
+		// mocked, throws exception
+		try {
+			$this->ArticleMock->find('first');
+			$this->assertEqual(
+				'Expected Exception',
+				'!!got none!!'
+			);
+		} catch (PDOException $e) {
+			// mock gave us the right message
+			$this->assertEqual(
+				$e->getMessage(),
+				'SQLSTATE[HY000]: General error: 1205 Lock wait timeout exceeded; try restarting transaction'
+			);
+			// mock gave us the "extra" info we need for the query...
+			$this->assertEqual(
+				$e->queryString,
+				'DELETE `IcingVersion` WHERE `id` = 1'
+			);
+		}
+	}
+
+	public function testExecuteMockedOnceThenWorked() {
+		$DboMock = $this->getMock('MysqlExtended', [
+			'connect',
+			'describe',
+			'executeOnParent',
+		]);
+		$DboMock
+			->expects($this->any())
+			->method('connect')
+			->will($this->returnValue($this->Dbo->connect()));
+		$DboMock
+			->expects($this->any())
+			->method('describe')
+			->will($this->returnValue($this->Dbo->describe($this->Article)));
+
+		// core execute: first time w/ Exception
+		$DboMock
+			->expects($this->at(0))
+			->method('executeOnParent')
+			->will($this->throwException($this->e));
+
+		// core execute: seconds time = result
+		$i = rand(99, 99999);
+		$DboMock
+			->expects($this->at(1))
+			->method('executeOnParent')
+			->will($this->returnValue($i));
+
+		// mocked, first time throws exception, then parent works
+		$this->assertEqual(
+			$DboMock->execute('SHOW STATUS'),
+			$i
+		);
+	}
+
+	public function testExecuteStuckLoop() {
+		$DboMock = $this->getMock('MysqlExtended', [
+			'connect',
+			'describe',
+			'executeOnParent',
+		]);
+
+		// parent wrapper for mocking
+		$DboMock
+			->expects($this->any())
+			->method('connect')
+			->will($this->returnValue($this->Dbo->connect()));
+		$DboMock
+			->expects($this->any())
+			->method('describe')
+			->will($this->returnValue($this->Dbo->describe($this->Article)));
+
+		$DboMock
+			->expects($this->at(0))
+			->method('executeOnParent')
+			->will($this->throwException($this->e));
+		$DboMock
+			->expects($this->at(1))
+			->method('executeOnParent')
+			->will($this->throwException($this->e));
+		$DboMock
+			->expects($this->at(2))
+			->method('executeOnParent')
+			->will($this->throwException($this->e));
+		$DboMock
+			->expects($this->at(3))
+			->method('executeOnParent')
+			->will($this->throwException($this->e));
+
+		// mocked, always throws exception
+		try {
+			$DboMock->execute('SHOW STATUS');
+			$this->assertEqual(
+				'Expected Exception',
+				'!!got none!!'
+			);
+		} catch (PDOException $e) {
+			// mock gave us the right message
+			$this->assertEqual(
+				$e->getMessage(),
+				'SQLSTATE[HY000]: General error: 1205 Lock wait timeout exceeded; try restarting transaction'
+			);
+			// mock gave us the "extra" info we need for the query...
+			$this->assertEqual(
+				$e->queryString,
+				'DELETE `IcingVersion` WHERE `id` = 1'
+			);
+		}
+	}
+
+
+	public function testTryExecuteAgain() {
+		// Mock it all up
+		$this->DboMock = $this->getMock('MysqlExtended', [
+			'connect',
+			'shouldWeExecuteAgain',
+			'tryExecuteAgainSleep',
+			'tryExecuteAgainAddRepeat',
+			'execute',
+		]);
+
+		$i = rand(99,99999);
+
+		$this->DboMock
+			->expects($this->once())
+			->method('shouldWeExecuteAgain')
+			->will($this->returnValue(true));
+		$this->DboMock
+			->expects($this->once())
+			->method('tryExecuteAgainSleep')
+			->will($this->returnValue(true));
+		$this->DboMock
+			->expects($this->once())
+			->method('tryExecuteAgainAddRepeat')
+			->will($this->returnValue(true));
+		$this->DboMock
+			->expects($this->once())
+			->method('execute')
+			->will($this->returnValue($i));
+
+		$this->assertEqual(
+			$this->DboMock->tryExecuteAgain($this->e, '', '', ''),
+			$i
+		);
+
+		// Mock it all up
+		$this->DboMock = $this->getMock('MysqlExtended', [
+			'connect',
+			'shouldWeExecuteAgain',
+			'tryExecuteAgainSleep',
+			'tryExecuteAgainAddRepeat',
+			'execute',
+		]);
+		$this->DboMock
+			->expects($this->once())
+			->method('shouldWeExecuteAgain')
+			->will($this->returnValue(false));
+
+		try {
+			$this->DboMock->tryExecuteAgain($this->e, '', '', '');
+			$this->assertEqual(
+				'Expected Exception',
+				'!!got none!!'
+			);
+		} catch (PDOException $e) {
+			// mock gave us the right message
+			$this->assertEqual(
+				$e->getMessage(),
+				'SQLSTATE[HY000]: General error: 1205 Lock wait timeout exceeded; try restarting transaction'
+			);
+			// mock gave us the "extra" info we need for the query...
+			$this->assertEqual(
+				$e->queryString,
+				'DELETE `IcingVersion` WHERE `id` = 1'
+			);
+		}
+
+	}
+
+	public function testShouldWeExecuteAgain() {
+		$this->assertTrue(
+			$this->Dbo->shouldWeExecuteAgain($this->e)
+		);
+		$this->assertFalse(
+			$this->Dbo->shouldWeExecuteAgain(true)
+		);
+		$this->assertFalse(
+			$this->Dbo->shouldWeExecuteAgain([])
+		);
+		$this->assertFalse(
+			$this->Dbo->shouldWeExecuteAgain(new PDOException('junk and stuff'))
+		);
+
+		// should not repeat more than 3 times
+		$this->assertTrue(
+			$this->Dbo->shouldWeExecuteAgain($this->e)
+		);
+		$this->Dbo->tryExecuteAgainAddRepeat($this->e);
+		$this->Dbo->tryExecuteAgainAddRepeat($this->e);
+		$this->Dbo->tryExecuteAgainAddRepeat($this->e);
+		$this->assertFalse(
+			$this->Dbo->shouldWeExecuteAgain($this->e)
+		);
+	}
+
+	public function testTryExecuteAgainAddRepeat() {
+		if (isset($this->Dbo->_tryExecuteAgain[$this->e->queryString])) {
+			unset($this->Dbo->_tryExecuteAgain[$this->e->queryString]);
+		}
+		$this->assertFalse(
+			isset($this->Dbo->_tryExecuteAgain[$this->e->queryString])
+		);
+
+		$this->Dbo->tryExecuteAgainAddRepeat($this->e);
+
+		$this->assertTrue(
+			isset($this->Dbo->_tryExecuteAgain[$this->e->queryString])
+		);
+		$this->assertEqual(
+			$this->Dbo->_tryExecuteAgain[$this->e->queryString],
+			1
+		);
+
+		$this->Dbo->tryExecuteAgainAddRepeat($this->e);
+		$this->Dbo->tryExecuteAgainAddRepeat($this->e);
+		$this->Dbo->tryExecuteAgainAddRepeat($this->e);
+		$this->Dbo->tryExecuteAgainAddRepeat($this->e);
+
+		$this->assertEqual(
+			$this->Dbo->_tryExecuteAgain[$this->e->queryString],
+			5
+		);
+	}
+
+	public function testTryExecuteAgainUnsetRepeat() {
+		$this->Dbo->_tryExecuteAgain[$this->e->queryString] = 2;
+
+		$this->Dbo->tryExecuteAgainUnsetRepeat();
+
+		$this->assertFalse(
+			isset($this->Dbo->_tryExecuteAgain[$this->e->queryString])
+		);
+		$this->assertFalse(
+			isset($this->Dbo->_tryExecuteAgain)
+		);
+	}
+
+	public function testTryExecuteAgainSleep() {
+		$this->Dbo->_tryExecuteAgain[$this->e->queryString] = 2;
+
+		// 1205 = 100 ms
+		$start = microtime(true);
+		$this->assertTrue(
+			$this->Dbo->tryExecuteAgainSleep($this->e)
+		);
+		$stop = microtime(true);
+		$delta = ($stop - $start);
+		$this->assertTrue($delta > 0.01);
+		$this->assertTrue($delta < 0.02);
+
+		// else, 1 ms
+		$this->e = new PDOException('blah blah');
+		$start = microtime(true);
+		$this->assertTrue(
+			$this->Dbo->tryExecuteAgainSleep($this->e)
+		);
+		$stop = microtime(true);
+		$delta = ($stop - $start);
+		$this->assertTrue($delta > 0.001);
+		$this->assertTrue($delta < 0.002);
+	}
+
+
+}
+

--- a/Test/Case/Model/Datasource/Database/MysqlExtendedTest.php
+++ b/Test/Case/Model/Datasource/Database/MysqlExtendedTest.php
@@ -204,14 +204,6 @@ class MysqlExtendedTest extends CakeTestCase {
 				'DELETE `IcingVersion` WHERE `id` = 1'
 			);
 		}
-	}
-
-	public function testExecuteMockedTwiceThenWorked() {
-		$DboMock = $this->getMock('MysqlExtended', [
-			'connect',
-			'describe',
-			'executeOnParent',
-		]);
 
 		// After query1 gets stuck in a loop of retrying and throwing an exception,
 		// Check to make sure query2 will still retry the appropriate amount of times

--- a/Test/Case/Model/Datasource/Database/MysqlExtendedTest.php
+++ b/Test/Case/Model/Datasource/Database/MysqlExtendedTest.php
@@ -204,6 +204,14 @@ class MysqlExtendedTest extends CakeTestCase {
 				'DELETE `IcingVersion` WHERE `id` = 1'
 			);
 		}
+	}
+
+	public function testExecuteMockedTwiceThenWorked() {
+		$DboMock = $this->getMock('MysqlExtended', [
+			'connect',
+			'describe',
+			'executeOnParent',
+		]);
 
 		// After query1 gets stuck in a loop of retrying and throwing an exception,
 		// Check to make sure query2 will still retry the appropriate amount of times

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,11 @@
 
 Portable Package of Utilities for CakePHP
 
+# Requirements
+
+* Php 5.4 or later
+* CakePHP 2.x
+
 # Helpers
 
 * CsvHelper


### PR DESCRIPTION
We were getting deadlocks more and more,
after the switch to InnoDB on our more active tables.

After research, we decided that automatic retry of the query was the way to go.
Mysql recommended it (it's in the error message).

This should only matter/happen in the case of PDOException Exceptions
which have the phrase "try restarting transaction" in the message.

This should only happen up to 3 times per query, per run.

In between each attempt there's a very brief pause.

If we do not retry, we just throw the PDOException.

Added logging for now, we may remove that at some point.