### PR TITLE
Change IV::cleanUpMinorVersions() and Throttle::purge() to use individual deletes instead of ranges

### DIFF
--- a/Model/IcingVersion.php
+++ b/Model/IcingVersion.php
@@ -144,7 +144,7 @@ class IcingVersion extends IcingAppModel {
 	public function cleanUpMinorVersions() {
 		return $this->deleteAll(array(
 			'IcingVersion.is_minor_version' => true
-		));
+		), true, true);
 	}
 
 	/**

--- a/Test/Case/Model/ThrottleTest.php
+++ b/Test/Case/Model/ThrottleTest.php
@@ -127,7 +127,7 @@ class ThrottleTest extends CakeTestCase {
 		$this->Throttle->create(false);
 		$this->Throttle->save(array('key' => 'b', 'expire_epoch' => time() + 5));
 		$this->assertEqual(5, $this->Throttle->find('count'));
-		$this->assertEqual(2, $this->Throttle->purge());
+		$this->assertEqual(true, $this->Throttle->purge());
 		$this->assertEqual(3, $this->Throttle->find('count'));
 	}
 


### PR DESCRIPTION
This should be better for the default "REPEATABLE READ" transaction level in InnoDB